### PR TITLE
Rework using IPC event

### DIFF
--- a/src/plugins/allCallTimers/EyeIcon.tsx
+++ b/src/plugins/allCallTimers/EyeIcon.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-export function EyeIcon({ height = 10, width = 10, className }: Readonly<{
+export function EyeIcon({ height = 16, width = 16, className }: Readonly<{
     height?: number;
     width?: number;
     className?: string;
@@ -15,6 +15,7 @@ export function EyeIcon({ height = 10, width = 10, className }: Readonly<{
             height={height}
             width={width}
             className={className}
+            style={{ color: "var(--channels-default)" }}
         >
             <path fill="currentColor" d="M332.229,90.04l14.238-27.159l-26.57-13.93L305.67,76.087c-19.618-8.465-40.875-13.849-63.17-15.523V30h48.269V0H164.231v30
         H212.5v30.563c-22.295,1.674-43.553,7.059-63.171,15.523L135.103,48.95l-26.57,13.93l14.239,27.16

--- a/src/plugins/allCallTimers/EyeIcon.tsx
+++ b/src/plugins/allCallTimers/EyeIcon.tsx
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classes } from "@utils/misc";
+
+import { cl } from "../translate/utils";
+
+export function EyeIcon({ height = 10, width = 10, className }: Readonly<{
+    height?: number;
+    width?: number;
+    className?: string;
+}>) {
+    return (
+        <svg
+            viewBox="0 0 455 455"
+            height={height}
+            width={width}
+            className={classes(cl("icon"), className)}
+        >
+            <path fill="currentColor" d="M332.229,90.04l14.238-27.159l-26.57-13.93L305.67,76.087c-19.618-8.465-40.875-13.849-63.17-15.523V30h48.269V0H164.231v30 H212.5v30.563c-22.295,1.674-43.553,7.059-63.171,15.523L135.103,48.95l-26.57,13.93l14.239,27.16 C67.055,124.958,30,186.897,30,257.5C30,366.576,118.424,455,227.5,455S425,366.576,425,257.5C425,186.896,387.944,124.958,332.229,90.04z M355,272.5H212.5V130h30v112.5H355V272.5z"/>
+        </svg>
+    );
+}

--- a/src/plugins/allCallTimers/EyeIcon.tsx
+++ b/src/plugins/allCallTimers/EyeIcon.tsx
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { classes } from "@utils/misc";
-
-import { cl } from "../translate/utils";
-
 export function EyeIcon({ height = 10, width = 10, className }: Readonly<{
     height?: number;
     width?: number;
@@ -18,9 +14,12 @@ export function EyeIcon({ height = 10, width = 10, className }: Readonly<{
             viewBox="0 0 455 455"
             height={height}
             width={width}
-            className={classes(cl("icon"), className)}
+            className={className}
         >
-            <path fill="currentColor" d="M332.229,90.04l14.238-27.159l-26.57-13.93L305.67,76.087c-19.618-8.465-40.875-13.849-63.17-15.523V30h48.269V0H164.231v30 H212.5v30.563c-22.295,1.674-43.553,7.059-63.171,15.523L135.103,48.95l-26.57,13.93l14.239,27.16 C67.055,124.958,30,186.897,30,257.5C30,366.576,118.424,455,227.5,455S425,366.576,425,257.5C425,186.896,387.944,124.958,332.229,90.04z M355,272.5H212.5V130h30v112.5H355V272.5z"/>
+            <path fill="currentColor" d="M332.229,90.04l14.238-27.159l-26.57-13.93L305.67,76.087c-19.618-8.465-40.875-13.849-63.17-15.523V30h48.269V0H164.231v30
+        H212.5v30.563c-22.295,1.674-43.553,7.059-63.171,15.523L135.103,48.95l-26.57,13.93l14.239,27.16
+        C67.055,124.958,30,186.897,30,257.5C30,366.576,118.424,455,227.5,455S425,366.576,425,257.5
+        C425,186.896,387.944,124.958,332.229,90.04z M355,272.5H212.5V130h30v112.5H355V272.5z"/>
         </svg>
     );
 }

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { useTimer } from "@utils/react";
+import { useFixedTimer } from "@utils/react";
 import { formatDurationMs } from "@utils/text";
 import { Tooltip } from "@webpack/common";
 
@@ -12,7 +12,7 @@ import { EyeIcon } from "./EyeIcon";
 import { settings } from "./index";
 
 export function Timer({ time }: Readonly<{ time: number; }>) {
-    const durationMs = useTimer({ deps: [time] });
+    const durationMs = useFixedTimer({ initialTime: time });
 
     if (settings.store.alwaysShow) {
         return <p style={{

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -5,14 +5,14 @@
  */
 
 import { useTimer } from "@utils/react";
+import { formatDurationMs } from "@utils/text";
 import { Tooltip } from "@webpack/common";
 
 import { EyeIcon } from "./EyeIcon";
 import { settings } from "./index";
 
 export function Timer({ time }: Readonly<{ time: number; }>) {
-    const timer = useTimer({});
-    const formatted = new Date(Date.now() - time).toISOString().substring(11, 19);
+    const durationMs = useTimer({ deps: [time] });
 
     if (settings.store.alwaysShow) {
         return <p style={{
@@ -29,12 +29,12 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
             background: "rgba(0,0,0,.5)",
             borderRadius: 3
         }
-        }> {formatted}</p>;
+        }> {formatDurationMs(durationMs)}</p>;
     } else {
         // show as a tooltip
         // TODO: should probably get the icon class dynamically
         return (
-            <Tooltip text={formatted}>
+            <Tooltip text={formatDurationMs(durationMs)}>
                 {({ onMouseEnter, onMouseLeave }) => (
                     <div
                         onMouseEnter={onMouseEnter}

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -32,6 +32,7 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
         }> {formatted}</p>;
     } else {
         // show as a tooltip
+        // TODO: should probably get the icon class dynamically
         return (
             <Tooltip text={formatted}>
                 {({ onMouseEnter, onMouseLeave }) => (
@@ -40,7 +41,7 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
                         onMouseLeave={onMouseLeave}
                         role="tooltip"
                     >
-                        <EyeIcon />
+                        <EyeIcon className="icon__1d60c" />
                     </div>
                 )}
             </Tooltip>

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -8,8 +8,8 @@ import { useFixedTimer } from "@utils/react";
 import { formatDurationMs } from "@utils/text";
 import { Tooltip } from "@webpack/common";
 
-import { EyeIcon } from "./EyeIcon";
 import { settings } from "./index";
+import { TimerIcon } from "./TimerIcon";
 
 export function Timer({ time }: Readonly<{ time: number; }>) {
     const durationMs = useFixedTimer({ initialTime: time });
@@ -40,7 +40,7 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
                         onMouseLeave={onMouseLeave}
                         role="tooltip"
                     >
-                        <EyeIcon />
+                        <TimerIcon />
                     </div>
                 )}
             </Tooltip>

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -32,7 +32,6 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
         }> {formatDurationMs(durationMs)}</p>;
     } else {
         // show as a tooltip
-        // TODO: should probably get the icon class dynamically
         return (
             <Tooltip text={formatDurationMs(durationMs)}>
                 {({ onMouseEnter, onMouseLeave }) => (

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -1,0 +1,49 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { useTimer } from "@utils/react";
+import { Tooltip } from "@webpack/common";
+
+import { EyeIcon } from "./EyeIcon";
+import { settings } from "./index";
+
+export function Timer({ time }: Readonly<{ time: number; }>) {
+    const timer = useTimer({});
+    const formatted = new Date(Date.now() - time).toISOString().substring(11, 19);
+
+    if (settings.store.alwaysShow) {
+        return <p style={{
+            margin: 0,
+            fontWeight: "bold",
+            letterSpacing: -2,
+            fontFamily: "monospace",
+            fontSize: 12,
+            color: "red",
+            position: "absolute",
+            bottom: 0,
+            right: 0,
+            padding: 2,
+            background: "rgba(0,0,0,.5)",
+            borderRadius: 3
+        }
+        }> {formatted}</p>;
+    } else {
+        // show as a tooltip
+        return (
+            <Tooltip text={formatted}>
+                {({ onMouseEnter, onMouseLeave }) => (
+                    <div
+                        onMouseEnter={onMouseEnter}
+                        onMouseLeave={onMouseLeave}
+                        role="tooltip"
+                    >
+                        <EyeIcon />
+                    </div>
+                )}
+            </Tooltip>
+        );
+    }
+}

--- a/src/plugins/allCallTimers/Timer.tsx
+++ b/src/plugins/allCallTimers/Timer.tsx
@@ -41,7 +41,7 @@ export function Timer({ time }: Readonly<{ time: number; }>) {
                         onMouseLeave={onMouseLeave}
                         role="tooltip"
                     >
-                        <EyeIcon className="icon__1d60c" />
+                        <EyeIcon />
                     </div>
                 )}
             </Tooltip>

--- a/src/plugins/allCallTimers/TimerIcon.tsx
+++ b/src/plugins/allCallTimers/TimerIcon.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-export function EyeIcon({ height = 16, width = 16, className }: Readonly<{
+export function TimerIcon({ height = 16, width = 16, className }: Readonly<{
     height?: number;
     width?: number;
     className?: string;

--- a/src/plugins/allCallTimers/index.tsx
+++ b/src/plugins/allCallTimers/index.tsx
@@ -12,9 +12,9 @@ import definePlugin, { OptionType } from "@utils/types";
 import { findStoreLazy } from "@webpack";
 import { Tooltip } from "@webpack/common";
 
+import { EyeIcon } from "./EyeIcon";
 
 const VoiceStateStore = findStoreLazy("VoiceStateStore");
-
 
 export const settings = definePluginSettings({
     alwaysShow: {
@@ -25,11 +25,10 @@ export const settings = definePluginSettings({
     },
 });
 
-
 export default definePlugin({
     name: "AllCallTimers",
     description: "Add call timer to all users in a server voice channel.",
-    authors: [Devs.Max],
+    authors: [Devs.Max, Devs.D3SOX],
 
     settings,
 
@@ -132,32 +131,35 @@ export default definePlugin({
 
     Timer({ time }: { time: number; }) {
         const timer = useTimer({});
-        const startTime = time;
-
-        const formatted = new Date(Date.now() - startTime).toISOString().substr(11, 8);
+        const formatted = new Date(Date.now() - time).toISOString().substring(11, 19);
 
         if (settings.store.alwaysShow) {
             return <p style={{
-                margin: 0, fontWeight: "bold", letterSpacing: -2, fontFamily: "monospace", fontSize: 12, color: "red", position: "absolute", bottom: 0, right: 0, padding: 2, background: "rgba(0,0,0,.5)", borderRadius: 3
+                margin: 0,
+                fontWeight: "bold",
+                letterSpacing: -2,
+                fontFamily: "monospace",
+                fontSize: 12,
+                color: "red",
+                position: "absolute",
+                bottom: 0,
+                right: 0,
+                padding: 2,
+                background: "rgba(0,0,0,.5)",
+                borderRadius: 3
             }
-            } > {formatted}</p >;
+            }> {formatted}</p>;
         } else {
             // show as a tooltip
-            const icon = <svg className="icon__1d60c" height="10" width="10" viewBox="0 0 455 455" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" xmlSpace="preserve">
-                <path fill="currentColor" d="M332.229,90.04l14.238-27.159l-26.57-13.93L305.67,76.087c-19.618-8.465-40.875-13.849-63.17-15.523V30h48.269V0H164.231v30
-        H212.5v30.563c-22.295,1.674-43.553,7.059-63.171,15.523L135.103,48.95l-26.57,13.93l14.239,27.16
-        C67.055,124.958,30,186.897,30,257.5C30,366.576,118.424,455,227.5,455S425,366.576,425,257.5
-        C425,186.896,387.944,124.958,332.229,90.04z M355,272.5H212.5V130h30v112.5H355V272.5z"/>
-            </svg>;
-
             return (
                 <Tooltip text={formatted}>
                     {({ onMouseEnter, onMouseLeave }) => (
                         <div
                             onMouseEnter={onMouseEnter}
                             onMouseLeave={onMouseLeave}
+                            role="tooltip"
                         >
-                            {icon}
+                            <EyeIcon />
                         </div>
                     )}
                 </Tooltip>

--- a/src/plugins/allCallTimers/index.tsx
+++ b/src/plugins/allCallTimers/index.tsx
@@ -7,12 +7,10 @@
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import { useTimer } from "@utils/react";
 import definePlugin, { OptionType } from "@utils/types";
 import { findStoreLazy } from "@webpack";
-import { Tooltip } from "@webpack/common";
 
-import { EyeIcon } from "./EyeIcon";
+import { Timer } from "./Timer";
 
 const VoiceStateStore = findStoreLazy("VoiceStateStore");
 
@@ -124,46 +122,11 @@ export default definePlugin({
             return;
         }
         const startTime = user.joinTime;
-        return <ErrorBoundary>
-            <this.Timer time={startTime} />
-        </ErrorBoundary>;
+
+        return (
+            <ErrorBoundary>
+                <Timer time={startTime} />
+            </ErrorBoundary>
+        );
     },
-
-    Timer({ time }: { time: number; }) {
-        const timer = useTimer({});
-        const formatted = new Date(Date.now() - time).toISOString().substring(11, 19);
-
-        if (settings.store.alwaysShow) {
-            return <p style={{
-                margin: 0,
-                fontWeight: "bold",
-                letterSpacing: -2,
-                fontFamily: "monospace",
-                fontSize: 12,
-                color: "red",
-                position: "absolute",
-                bottom: 0,
-                right: 0,
-                padding: 2,
-                background: "rgba(0,0,0,.5)",
-                borderRadius: 3
-            }
-            }> {formatted}</p>;
-        } else {
-            // show as a tooltip
-            return (
-                <Tooltip text={formatted}>
-                    {({ onMouseEnter, onMouseLeave }) => (
-                        <div
-                            onMouseEnter={onMouseEnter}
-                            onMouseLeave={onMouseLeave}
-                            role="tooltip"
-                        >
-                            <EyeIcon />
-                        </div>
-                    )}
-                </Tooltip>
-            );
-        }
-    }
 });

--- a/src/plugins/callTimer/index.tsx
+++ b/src/plugins/callTimer/index.tsx
@@ -16,35 +16,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Settings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
 import { useTimer } from "@utils/react";
+import { formatDurationMs } from "@utils/text";
 import definePlugin, { OptionType } from "@utils/types";
 import { React } from "@webpack/common";
-
-function formatDuration(ms: number) {
-    // here be dragons (moment fucking sucks)
-    const human = Settings.plugins.CallTimer.format === "human";
-
-    const format = (n: number) => human ? n : n.toString().padStart(2, "0");
-    const unit = (s: string) => human ? s : "";
-    const delim = human ? " " : ":";
-
-    // thx copilot
-    const d = Math.floor(ms / 86400000);
-    const h = Math.floor((ms % 86400000) / 3600000);
-    const m = Math.floor(((ms % 86400000) % 3600000) / 60000);
-    const s = Math.floor((((ms % 86400000) % 3600000) % 60000) / 1000);
-
-    let res = "";
-    if (d) res += `${d}d `;
-    if (h || res) res += `${format(h)}${unit("h")}${delim}`;
-    if (m || res || !human) res += `${format(m)}${unit("m")}${delim}`;
-    res += `${format(s)}${unit("s")}`;
-
-    return res;
-}
 
 export default definePlugin({
     name: "CallTimer",
@@ -90,6 +67,6 @@ export default definePlugin({
             deps: [channelId]
         });
 
-        return <p style={{ margin: 0 }}>Connected for <span style={{ fontFamily: "var(--font-code)" }}>{formatDuration(time)}</span></p>;
+        return <p style={{ margin: 0 }}>Connected for <span style={{ fontFamily: "var(--font-code)" }}>{formatDurationMs(time)}</span></p>;
     }
 });

--- a/src/plugins/vcNarrator/index.tsx
+++ b/src/plugins/vcNarrator/index.tsx
@@ -25,16 +25,7 @@ import { wordsToTitle } from "@utils/text";
 import definePlugin, { OptionType, PluginOptionsItem } from "@utils/types";
 import { findStoreLazy } from "@webpack";
 import { Button, ChannelStore, Forms, GuildMemberStore, SelectedChannelStore, SelectedGuildStore, useMemo, UserStore } from "@webpack/common";
-
-interface VoiceState {
-    userId: string;
-    channelId?: string;
-    oldChannelId?: string;
-    deaf: boolean;
-    mute: boolean;
-    selfDeaf: boolean;
-    selfMute: boolean;
-}
+import { VoiceState } from "@webpack/types";
 
 const VoiceStateStore = findStoreLazy("VoiceStateStore");
 

--- a/src/plugins/vcNarrator/index.tsx
+++ b/src/plugins/vcNarrator/index.tsx
@@ -23,7 +23,7 @@ import { Logger } from "@utils/Logger";
 import { Margins } from "@utils/margins";
 import { wordsToTitle } from "@utils/text";
 import definePlugin, { OptionType, PluginOptionsItem } from "@utils/types";
-import { findByPropsLazy } from "@webpack";
+import { findStoreLazy } from "@webpack";
 import { Button, ChannelStore, Forms, GuildMemberStore, SelectedChannelStore, SelectedGuildStore, useMemo, UserStore } from "@webpack/common";
 
 interface VoiceState {
@@ -36,7 +36,7 @@ interface VoiceState {
     selfMute: boolean;
 }
 
-const VoiceStateStore = findByPropsLazy("getVoiceStatesForChannel", "getCurrentClientVoiceChannelId");
+const VoiceStateStore = findStoreLazy("VoiceStateStore");
 
 // Mute/Deaf for other people than you is commented out, because otherwise someone can spam it and it will be annoying
 // Filtering out events is not as simple as just dropping duplicates, as otherwise mute, unmute, mute would

--- a/src/utils/react.tsx
+++ b/src/utils/react.tsx
@@ -144,3 +144,22 @@ export function useTimer({ interval = 1000, deps = [] }: TimerOpts) {
 
     return time;
 }
+
+interface FixedTimerOpts {
+    interval?: number;
+    initialTime?: number;
+}
+
+export function useFixedTimer({ interval = 1000, initialTime = Date.now() }: FixedTimerOpts) {
+    const [time, setTime] = useState(Date.now() - initialTime);
+
+    useEffect(() => {
+        const intervalId = setInterval(() => setTime(Date.now() - initialTime), interval);
+
+        return () => {
+            clearInterval(intervalId);
+        };
+    }, [initialTime]);
+
+    return time;
+}

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Settings } from "@api/Settings";
 import { moment } from "@webpack/common";
 
 // Utils for readable text transformations eg: `toTitle(fromKebab())`
@@ -91,6 +92,32 @@ export function formatDuration(time: number, unit: Units, short: boolean = false
     }
 
     return res.length ? res : `0 ${getUnitStr(unit, false, short)}`;
+}
+/**
+ * Formats a duration in milliseconds into a human-readable string
+ * @param ms The duration in milliseconds
+ */
+export function formatDurationMs(ms: number) {
+    // here be dragons (moment fucking sucks)
+    const human = Settings.plugins.CallTimer.format === "human";
+
+    const format = (n: number) => human ? n : n.toString().padStart(2, "0");
+    const unit = (s: string) => human ? s : "";
+    const delim = human ? " " : ":";
+
+    // thx copilot
+    const d = Math.floor(ms / 86400000);
+    const h = Math.floor((ms % 86400000) / 3600000);
+    const m = Math.floor(((ms % 86400000) % 3600000) / 60000);
+    const s = Math.floor((((ms % 86400000) % 3600000) % 60000) / 1000);
+
+    let res = "";
+    if (d) res += `${d}d `;
+    if (h || res) res += `${format(h)}${unit("h")}${delim}`;
+    if (m || res || !human) res += `${format(m)}${unit("m")}${delim}`;
+    res += `${format(s)}${unit("s")}`;
+
+    return res;
 }
 
 /**

--- a/src/webpack/common/types/index.d.ts
+++ b/src/webpack/common/types/index.d.ts
@@ -21,4 +21,5 @@ export * from "./fluxEvents";
 export * from "./menu";
 export * from "./stores";
 export * from "./utils";
+export * from "./voicestate";
 

--- a/src/webpack/common/types/voicestate.d.ts
+++ b/src/webpack/common/types/voicestate.d.ts
@@ -1,0 +1,20 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface VoiceState {
+    userId: string;
+    channelId?: string;
+    oldChannelId?: string;
+    deaf: boolean;
+    mute: boolean;
+    selfDeaf: boolean;
+    selfMute: boolean;
+    selfStream: boolean;
+    selfVideo: boolean;
+    sessionId: string;
+    suppress: boolean;
+    requestToSpeakTimestamp: string | null;
+}


### PR DESCRIPTION
- A lot of refactoring
- Don't use hard-coded Discord class for icon style
- Use existing method to format the duration
- Added a setting whether to track it for yourself or not (Maybe we could depend on the state of the CallTimer plugin here)
- Now using IPC events and a simple map to store the join times